### PR TITLE
Atualizando link para grupo Dart Brasil

### DIFF
--- a/_posts/2016-10-26-dartbr.markdown
+++ b/_posts/2016-10-26-dartbr.markdown
@@ -2,6 +2,6 @@
 layout: post
 title:  "Dart Language Brasil"
 categories: jekyll update
-link-telegram: https://telegram.me/dartbr
+link-telegram: https://telegram.me/dartbrasil
 ---
 Colaboração: Denis Albuquerque (@zidenis)


### PR DESCRIPTION
O link anteriormente utilizado aponta para um canal de divulgação, quando a intenção era criar um grupo de discussão. O novo grupo de discussão foi criado e os membros do canal foram solicitados a migrar para o grupo.
