### PR TITLE
Adiciona link para o canal Somos KDE (KDE Brasil)

### DIFF
--- a/_posts/kdebrasil.markdown
+++ b/_posts/kdebrasil.markdown
@@ -4,4 +4,4 @@ title:  "KDE Brasil"
 categories:
 link-telegram: https://telegram.me/joinchat/BstFRj9eUM4B7fZE3yEnLQ
 ---
-Discussões em português sobre a comunidade e softwares KDE
+Discussões em português sobre a comunidade e softwares KDE. Canal com posts de blogs em português: https://t.me/somos_kde.


### PR DESCRIPTION
Adiciona na descrição do grupo KDE Brasil um link para o
canal com posts em português sobre o KDE, o somos_kde