### PR TITLE
Remove Android Drops Brasil

### DIFF
--- a/_posts/2017-01-04-android-drops-br.markdown
+++ b/_posts/2017-01-04-android-drops-br.markdown
@@ -1,7 +1,0 @@
----
-layout: post
-title:  "Android Drops Brasil"
-categories: jekyll update
-link-telegram: https://telegram.me/androiddropsbr
----
-Colaboração: José Naves (@josenaves)


### PR DESCRIPTION
This group does not exist anymore.