### PR TITLE
Fundido a outro grupo

### DIFF
--- a/_posts/2017-02-07-freecad-openscad-blender.markdown
+++ b/_posts/2017-02-07-freecad-openscad-blender.markdown
@@ -2,6 +2,6 @@
 layout: post
 title:  "FreeCAD, OpenSCAD & Blender em modelagem paramétrica"
 categories: 3d
-link-telegram: https://t.me/modelagem3dlivre 
+link-telegram: https://t.me/joinchat/AAAAAECCeJc0TQOoRnBFtA
 ---
 Colaboração: Cláudio "Patola" Sampaio (@makerlinux)


### PR DESCRIPTION
O grupo estava sem muito assunto e tinha um escopo muito parecid com o de modelagem 3d open-source, então fundi os dois grupos fazendo esse voltar ao link privado original.