### PR TITLE
EthereumBR, Android Dev Drops, iOS Dev Drops and React Native Drops

### DIFF
--- a/_posts/2017-01-06-react-native-drops.markdown
+++ b/_posts/2017-01-06-react-native-drops.markdown
@@ -2,6 +2,8 @@
 layout: post
 title:  "React Native Drops"
 categories: jekyll update
-link-telegram: https://telegram.me/reactnativedrops
+link-telegram: https://t.me/reactnativedrops
 ---
+Papo sobre desenvolvimento mobile com React Native.
+
 Colaboração: José Naves (@josenaves)

--- a/_posts/2018-02-14-androiddevdrops.markdown
+++ b/_posts/2018-02-14-androiddevdrops.markdown
@@ -1,0 +1,9 @@
+---
+layout: post
+title:  "Android Dev Drops"
+categories: jekyll update
+link-telegram: https://t.me/android_drops
+---
+Bate-papo sobre desenvolvimento nativo para Android. 
+
+Colaboração: José Naves (@josenaves)

--- a/_posts/2018-02-14-ethereumBR.markdown
+++ b/_posts/2018-02-14-ethereumBR.markdown
@@ -1,0 +1,12 @@
+---
+layout: post
+title:  "EthereumBR"
+categories: jekyll update
+link-telegram: https://t.me/etherbr
+---
+Bate-papo sobre Ethereum, Solidity, e tecnologias relacionadas.
+
+Colaboração: José Naves (@josenaves) e Marcelo Creimer (@creimer)
+
+
+

--- a/_posts/2018-02-15-iosdevdrops.markdown
+++ b/_posts/2018-02-15-iosdevdrops.markdown
@@ -1,0 +1,12 @@
+---
+layout: post
+title:  "iOS Dev Drops"
+categories: jekyll update
+link-telegram: https://t.me/iosdrops
+---
+
+Bate-papo sobre desenvolvimento nativo para iOS.
+
+Colaboração: José Naves (@josenaves)
+
+


### PR DESCRIPTION
This PR adds three new groups: EthereumBR, Android Dev Drops, and iOS Dev Drops.

It also changes the description of React Native Drops group.