### PR TITLE
Delete 2017-01-06-bauru-tec.markdown

### DIFF
--- a/_posts/2017-01-06-bauru-tec.markdown
+++ b/_posts/2017-01-06-bauru-tec.markdown
@@ -1,7 +1,0 @@
----
-layout: post
-title:  "Bauru Tec"
-categories: bauru developers programacao
-link-telegram: https://t.me/joinchat/AAAAAD_T9LRcDxyPTWqZ2Q
----
-Colaboração: Marcos Felipe (@omarkdev)


### PR DESCRIPTION
Delete bauru tec because the group not-exist more, the group changed the name to Crow Labs.