### PR TITLE
updated emacs group link to new grupo with administration and without bot spammers

### DIFF
--- a/_posts/2018-09-19-emacs.markdown
+++ b/_posts/2018-09-19-emacs.markdown
@@ -2,6 +2,6 @@
 layout: post
 title:  "Emacs Brasil"
 categories: emacs, elisp, editor de texto
-link-telegram: https://t.me/emacsBr
+link-telegram: https://t.me/emacsbrasil
 ---
-Grupo dedicado a discussões relacionadas ao editor de texto emacs.
+Grupo dedicado a discussões relacionadas ao editor de texto emacs, Hacker Culture, Lisp e seus dialetos, o Projeto GNU e FOSS em geral.


### PR DESCRIPTION
infelizmente o grupo @emacsBr foi abandonado pelo criador, que não deixou nenhum admin para cuidar do grupo, e os bots começaram a spammar o mesmo.

por isso a comunidade decidiu migrar para um novo grupo onde pudessemos administrar e controlar os bots.
o novo grupo é @emacsbrasil

um simples join no grupo antigo @emacsBr permite verificar a veracidade destas informações.