### PR TITLE
ajustando o nome do arquivo para ficar de acordo com o nome do grupo

### DIFF
--- a/_posts/2019-11-21-nativescript-br.markdown
+++ b/_posts/2019-11-21-nativescript-br.markdown
@@ -1,8 +1,0 @@
----
-layout: post
-title:  "NativescriptVue Brasil"
-categories: js vuejs mobile
-link-telegram: https://t.me/nativescriptvuebr
----
-Também conhecido como NsV - NativescriptVue
-Colaboração: Jeudi Prando (@jeudi)

--- a/_posts/2019-11-21-nativescriptvue-br.markdown
+++ b/_posts/2019-11-21-nativescriptvue-br.markdown
@@ -1,0 +1,11 @@
+---
+layout: post
+title:  "NativescriptVue Brasil"
+categories: js vuejs mobile
+link-telegram: https://t.me/nativescriptvuebr
+---
+Também conhecido como **NsV - NativescriptVue**  
+
+Utilizando [Nativescript]((https://nativescript-vue.org/)) como base e os super poderes do [Vuejs](https://br.vuejs.org/index.html), para desenvolver aplicativos mobile nativos.  
+
+Colaboração: Jeudi Prando (@jeudi)  


### PR DESCRIPTION
existe um grupo com o nome nativescript br
verificar aqui [https://t.me/nativescriptbr]

estou renomeando o nome do arquivo
de nativescript-br
para nativescriptvue-br

para nao ficar em conflito com o grupo existente e refletir verdadeiramente o nome do grupo para o qual o arquivo/post aponta
